### PR TITLE
Fix GH-22 (TypeError with Streamlit 0.84)

### DIFF
--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -168,6 +168,8 @@ def AgGrid(
         raise(ex)
 
     if component_value:
+        if isinstance(component_value, str):
+            component_value = simplejson.loads(component_value)
         frame = pd.DataFrame(component_value["rowData"])
         original_types = component_value["originalDtypes"]
 


### PR DESCRIPTION
In Streamlit 0.84, `component_value` is a `str` with JSON-encoded data, rather than a `dict` as with previous Streamlit versions.

Added a check for `str` and if it's a `str`, we decode the JSON into a `dict`.

Fixes: GH-22