### PR TITLE
Fix enableRowGroup warning

### DIFF
--- a/st_aggrid/grid_options_builder.py
+++ b/st_aggrid/grid_options_builder.py
@@ -80,8 +80,9 @@ class GridOptionsBuilder:
             "filter": filterable,
             "resizable": resizable,
             "sortable": sorteable,
-            "enableRowGroup": groupable,
         }
+        if groupable:
+            defaultColDef["enableRowGroup"] = groupable
 
         if other_default_column_properties:
             defaultColDef = {**defaultColDef, **other_default_column_properties}


### PR DESCRIPTION
```
ag-Grid: enableRowGroup is only valid with ag-Grid Enterprise Module
@ag-grid-enterprise/row-grouping - your column definition should not
have enableRowGroup
```