### PR TITLE
Improve performance for large dataframes by caching row_data and adding SELECTION_ONLY data return mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "aggrid_dev",
+    "image": "nikolaik/python-nodejs:latest",
+    "workspaceFolder": "/code",
+    "runArgs": [
+        "--network=host"
+    ],
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "workspaceMount": "src=${localWorkspaceFolder},dst=/code,type=bind,consistency=cached",
+    "postCreateCommand": "cd /st_aggrid/frontend && npm install",
+    "extensions": ["ms-python.python", "eamodio.gitlens"]
+}

--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -1,4 +1,5 @@
 import os
+import streamlit as st
 import streamlit.components.v1 as components
 import pandas as pd
 import numpy as np
@@ -150,23 +151,28 @@ def AgGrid(
         gb = GridOptionsBuilder.from_dataframe(dataframe,**default_column_parameters)
         gridOptions = gb.build()
 
-    def cast_to_serializable(value):
-        isoformat = getattr(value, 'isoformat', None)
-        
-        if ((isoformat) and callable(isoformat)):
-            return isoformat()
+    @st.cache
+    def get_row_data(df):
+        def cast_to_serializable(value):
+            isoformat = getattr(value, 'isoformat', None)
+            
+            if ((isoformat) and callable(isoformat)):
+                return isoformat()
 
-        elif isinstance(value, Number):
-            if (np.isnan(value) or np.isinf(value)):
+            elif isinstance(value, Number):
+                if (np.isnan(value) or np.isinf(value)):
+                    return value.__str__()
+            
+                return value
+            else:
                 return value.__str__()
         
-            return value
-        else:
-            return value.__str__()
-    
-    json_frame = dataframe.applymap(cast_to_serializable) 
-    row_data = json_frame.to_dict(orient="records")
-    row_data = simplejson.dumps(row_data, ignore_nan=True)
+        json_frame = dataframe.applymap(cast_to_serializable) 
+        row_data = json_frame.to_dict(orient="records")
+        row_data = simplejson.dumps(row_data, ignore_nan=True)
+        return row_data
+
+    row_data = get_row_data(dataframe)
 
     if allow_unsafe_jscode:
         walk_gridOptions(gridOptions, lambda v: v.js_code if isinstance(v, JsCode) else v)

--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -83,6 +83,7 @@ def AgGrid(
             DataReturnMode.AS_INPUT             -> Returns grid data as inputed. Includes cell editions
             DataReturnMode.FILTERED             -> Returns filtered grid data, maintains input order
             DataReturnMode.FILTERED_AND_SORTED  -> Returns grid data filtered and sorted
+            DataReturnMode.SELECTION_ONLY       -> Returns only the selected_rows and no data
         Defaults to DataReturnMode.AS_INPUT.
         
     allow_unsafe_jscode : bool, optional

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -233,6 +233,9 @@ class AgGrid extends StreamlitComponentBase<State> {
       case 2: //FILTERED_SORTED_DATA
         this.api.forEachNodeAfterFilterAndSort((row) => { if (!row.group) { returnData.push(row.data) } })
         break;
+
+      case 3: //SELECTION_ONLY
+        break;
     }
 
     let returnValue = {

--- a/st_aggrid/shared.py
+++ b/st_aggrid/shared.py
@@ -12,6 +12,7 @@ class DataReturnMode(IntEnum):
     AS_INPUT = 0
     FILTERED = 1
     FILTERED_AND_SORTED = 2
+    SELECTION_ONLY = 3
 
 # stole from https://github.com/andfanilo/streamlit-echarts/blob/master/streamlit_echarts/frontend/src/utils.js Thanks andfanilo
 class JsCode:


### PR DESCRIPTION
improving performance for large dataframes by caching row_data.

I found this to be a lot faster for my application where I have a large dataframe and reload the page often by user interaction with ui widgets.
Not sure if it can have any side effects, but it should invalidate the cache if the dataframe changes, so I think it is reasonably safe to do.