### PR TITLE
Fix typo in grid options builder

### DIFF
--- a/st_aggrid/grid_options_builder.py
+++ b/st_aggrid/grid_options_builder.py
@@ -47,7 +47,7 @@ class GridOptionsBuilder:
 
         return gb
 
-    def configure_default_column(self, min_column_width=5, resizable=True, filterable=True, sorteable=True, editable=False, groupable=False, **other_default_column_properties):
+    def configure_default_column(self, min_column_width=5, resizable=True, filterable=True, sortable=True, editable=False, groupable=False, **other_default_column_properties):
         """Configure default column.
 
         Args:
@@ -60,8 +60,8 @@ class GridOptionsBuilder:
             filterable (bool, optional):
                 All columns will be filterable. Defaults to True.
 
-            sorteable (bool, optional):
-                All columns will be sorteable. Defaults to True.
+            sortable (bool, optional):
+                All columns will be sortable. Defaults to True.
 
             groupable (bool, optional):
                 All columns will be groupable based on row values. Defaults to True.
@@ -81,7 +81,7 @@ class GridOptionsBuilder:
             "editable": editable,
             "filter": filterable,
             "resizable": resizable,
-            "sortable": sorteable,
+            "sortable": sortable,
         }
         if groupable:
             defaultColDef["enableRowGroup"] = groupable

--- a/st_aggrid/grid_options_builder.py
+++ b/st_aggrid/grid_options_builder.py
@@ -47,7 +47,7 @@ class GridOptionsBuilder:
 
         return gb
 
-    def configure_default_column(self, min_column_width=5, resizable=True, filterable=True, sortable=True, editable=False, groupable=False, **other_default_column_properties):
+    def configure_default_column(self, min_column_width=5, resizable=True, filterable=True, sortable=True, editable=False, groupable=False, sorteable=None, **other_default_column_properties):
         """Configure default column.
 
         Args:
@@ -63,6 +63,9 @@ class GridOptionsBuilder:
             sortable (bool, optional):
                 All columns will be sortable. Defaults to True.
 
+            sorteable (bool, optional):
+                Backwards compatibility alias for sortable. Overrides sortable if not None.
+
             groupable (bool, optional):
                 All columns will be groupable based on row values. Defaults to True.
 
@@ -76,6 +79,9 @@ class GridOptionsBuilder:
                 Key value pairs that will be merged to defaultColDef dict.
                 Chech ag-grid documentation.
         """
+        if sorteable is not None:
+            sortable = sorteable
+
         defaultColDef = {
             "minWidth": min_column_width,
             "editable": editable,


### PR DESCRIPTION
`GridOptionsBuilder.configure_default_column` has an argument "`sorteable`" which should be "`sortable`". The first commit in this PR (04c468af086c5427cc19fc4b5711740b71200e8f) fixes that typo. Additionally, the second commit (57af43263d12a50b500ce32e09a844bdc7205164) implements backwards compatibility so as not to break existing code using the erroneous "sorteable" parameter. Backwards compatibility was added as a separate commit to make it easier to not include if not desired.