### PR TITLE
simplify row building and avoid costly applymap

### DIFF
--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -155,30 +155,7 @@ def AgGrid(
         gb = GridOptionsBuilder.from_dataframe(dataframe,**default_column_parameters)
         gridOptions = gb.build()
 
-    def get_row_data(df):
-        def cast_to_serializable(value):
-            if isinstance(value, pd.DataFrame):
-                return get_row_data(value)
-
-            isoformat = getattr(value, 'isoformat', None)
-
-            if ((isoformat) and callable(isoformat)):
-                return isoformat()
-
-            elif isinstance(value, Number):
-                if (np.isnan(value) or np.isinf(value)):
-                    return value.__str__()
-
-                return value
-            else:
-                return value.__str__()
-    
-        json_frame = df.applymap(cast_to_serializable) 
-        row_data = json_frame.to_dict(orient="records")
-        row_data = simplejson.dumps(row_data, ignore_nan=True)
-        return row_data
-
-    row_data = get_row_data(dataframe)
+    row_data = dataframe.to_json(orient = "records", date_format="iso")
 
     if allow_unsafe_jscode:
         walk_gridOptions(gridOptions, lambda v: v.js_code if isinstance(v, JsCode) else v)


### PR DESCRIPTION
not sure if there was a special reason not to use the pandas to_json but for me it improved performance significantly and it also makes the code simpler.
... it also handles the nested dataframe case nicely without the need to convert it to a JSON string seperately.