### PR TITLE
Update __init__.py

### DIFF
--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -250,7 +250,7 @@ def AgGrid(
 
                 text_columns = [k for k,v in original_types.items() if v in ['O','S','U']]
                 if text_columns:
-                    frame.loc[:,text_columns]  = frame.loc[:,text_columns].astype(str)
+                    frame.loc[:,text_columns.keys()]  = frame.loc[:,text_columns.keys()].astype(str)
 
                 date_columns = [k for k,v in original_types.items() if v == "M"]
                 if date_columns:


### PR DESCRIPTION
A fix to avoid the following Pandas warning:
FutureWarning: Passing a dict as an indexer is deprecated and will raise in a future version. Use a list instead.

(So the fix is just passing the dictionary keys instead of the dictionary itself.)