### PR TITLE
Enable User Column Filters on Instantiation

### DIFF
--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -41,6 +41,7 @@ def AgGrid(
     reload_data:bool=False,
     theme:str='light',
     custom_css=None,
+    default_column_filters: typing.Optional[str] = None,
     key: typing.Any=None,
     **default_column_parameters) -> typing.Dict:
     """Reders a DataFrame using AgGrid.
@@ -126,6 +127,10 @@ def AgGrid(
     custom_css (dict, optional):
         Custom CSS rules to be added to the component's iframe.
 
+    default_column_filters : str, optional
+        Default column filters to apply on instantiation. Requires enterprise license.
+        Defaults to None.
+
     key : typing.Any, optional
         Streamlits key argument. Check streamlit's documentation.
         Defaults to None.
@@ -146,6 +151,7 @@ def AgGrid(
     response = {}
     response["data"] = dataframe
     response["selected_rows"] = []
+    response["column_filters"] = None
     
     #basic numpy types of dataframe
     frame_dtypes = dict(zip(dataframe.columns, (t.kind for t in dataframe.dtypes)))
@@ -225,7 +231,8 @@ def AgGrid(
             reload_data=reload_data,
             theme=theme,
             custom_css=custom_css,
-            key=key
+            default_column_filters=default_column_filters,
+            key=key,
             )
 
     except components.components.MarshallComponentException as ex:
@@ -250,7 +257,7 @@ def AgGrid(
 
                 text_columns = [k for k,v in original_types.items() if v in ['O','S','U']]
                 if text_columns:
-                    frame.loc[:,text_columns.keys()]  = frame.loc[:,text_columns.keys()].astype(str)
+                    frame.loc[:,text_columns]  = frame.loc[:,text_columns].astype(str)
 
                 date_columns = [k for k,v in original_types.items() if v == "M"]
                 if date_columns:
@@ -268,5 +275,6 @@ def AgGrid(
 
         response["data"] = frame
         response["selected_rows"] = component_value["selectedRows"]
+        response["column_filters"] = component_value["columnFilters"]
     
     return response

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -68,6 +68,7 @@ class AgGrid extends StreamlitComponentBase<State> {
   private allowUnsafeJsCode: boolean = false
   private fitColumnsOnGridLoad: boolean = false
   private gridOptions: any
+  private defaultColumnFilters: string
 
   constructor(props: any) {
     super(props)
@@ -89,6 +90,7 @@ class AgGrid extends StreamlitComponentBase<State> {
     this.manualUpdateRequested = (this.props.args.update_mode === 1)
     this.allowUnsafeJsCode = this.props.args.allow_unsafe_jscode
     this.fitColumnsOnGridLoad = this.props.args.fit_columns_on_grid_load
+    this.defaultColumnFilters = this.props.args.default_column_filters
     
     this.columnFormaters = {
       columnTypes: {
@@ -203,7 +205,13 @@ class AgGrid extends StreamlitComponentBase<State> {
     this.columnApi = event.columnApi
 
     this.setUpdateMode()
-    this.api.addEventListener('firstDataRendered', (e: any) => this.fitColumns())
+    this.api.addEventListener('firstDataRendered', (e: any) => {
+      this.fitColumns()
+      if (this.defaultColumnFilters) {
+        let filters = JSON.parse(this.defaultColumnFilters.slice(1, -1))
+        this.api.setFilterModel(filters)
+      }
+    })
 
     this.api.setRowData(this.state.rowData)
 
@@ -270,7 +278,8 @@ class AgGrid extends StreamlitComponentBase<State> {
     let returnValue = {
       originalDtypes: this.frameDtypes,
       rowData: returnData,
-      selectedRows: this.api.getSelectedRows()
+      selectedRows: this.api.getSelectedRows(),
+      columnFilters: JSON.stringify(this.api.getFilterModel())
     }
 
     Streamlit.setComponentValue(returnValue)

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -208,7 +208,7 @@ class AgGrid extends StreamlitComponentBase<State> {
     this.api.addEventListener('firstDataRendered', (e: any) => {
       this.fitColumns()
       if (this.defaultColumnFilters) {
-        let filters = JSON.parse(this.defaultColumnFilters.slice(1, -1))
+        let filters = JSON.parse(this.defaultColumnFilters)
         this.api.setFilterModel(filters)
       }
     })


### PR DESCRIPTION
For my specific use case, there is a huge advantage to letting my users ultimately export their current column filters and later re-upload them. This can shortcut a lot of manual filtering if the user does pretty routine analysis.

This pull request exposes the ability to both read/write the column filters through the Ag-Grid enterprise `setFilterModel` and `getFilterModel` functions. On instantiation (or whenever the AgGrid Streamlit component `key` changes), these column filters can be applied automatically for the user. After the user filters the data, their filters can be accessed through the new `column_filters` field in the component value/response.

Please let me know if you have any questions. Happy to create a minimal Streamlit example if my use case is not clear.