### PR TITLE
Update index.html

### DIFF
--- a/st_aggrid/frontend/public/index.html
+++ b/st_aggrid/frontend/public/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="bootstrap.min.css" />
 </head>
 
-<body>
+<body style="background-color: transparent;">
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--


### PR DESCRIPTION
This solves the problem of an eventual white page been displayed for a short moment (milliseconds) in slow computers (or sufficient slow rendering for some reason), which can be noticeable when using a dark theme.

What it does is to set the body background color to 'transparent' (while the default is 'white'), which is the color used by the browser before it applies the CSS... I know it's hard to simulate this issue, but trust me, it happens. =) It's also good practice to use transparent body background when the component (the page in the iframe) is guarantee to override that with CSS.