### PR TITLE
Fix issue with st.tabs where grids on inactive tabs disappear

### DIFF
--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -343,7 +343,9 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
 
   private resizeGridContainer() {
     const renderedGridHeight = this.gridContainerRef.current?.clientHeight
-    Streamlit.setFrameHeight(renderedGridHeight)
+    if (renderedGridHeight && renderedGridHeight > 0) {
+      Streamlit.setFrameHeight(renderedGridHeight)
+    }
   }
 
   private fitColumns() {

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -215,6 +215,7 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
   private gridOptions: any
   private gridContainerRef: React.RefObject<HTMLDivElement>
   private isGridAutoHeightOn: boolean
+  private fitColumnsDone: boolean = false
 
   constructor(props: any) {
     super(props)
@@ -345,6 +346,12 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
     const renderedGridHeight = this.gridContainerRef.current?.clientHeight
     if (renderedGridHeight && renderedGridHeight > 0) {
       Streamlit.setFrameHeight(renderedGridHeight)
+      // Run fitColumns only once when the grid first becomes visible with height > 0
+      // This solves column_auto_size_mode issue with st.tabs causing all columns to render with ~0 width
+      if (!this.fitColumnsDone) {
+        this.fitColumns()
+        this.fitColumnsDone = true
+      }
     }
   }
 
@@ -478,7 +485,6 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
 
     this.api.addEventListener("firstDataRendered", (e: any) => {
       this.resizeGridContainer();
-      this.fitColumns()
     })
 
     this.attachStreamlitRerunToEvents(this.api)

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -157,7 +157,7 @@ function parseJsCodeFromPython(v: string) {
 }
 
 function GridToolBar(props: any) {
-  if (true) {
+  if (props.enabled) {
     return (
       <div id="gridToolBar" style={{ paddingBottom: 30 }}>
         <div className="ag-row-odd ag-row-no-focus ag-row ag-row-level-0 ag-row-position-absolute">

--- a/st_aggrid/frontend/src/agGridStyle.scss
+++ b/st_aggrid/frontend/src/agGridStyle.scss
@@ -42,3 +42,8 @@
 ));
 
 @import "@fontsource/source-sans-pro";
+
+// Hack to fix last column clipping issue with grids in st.tabs
+.ag-center-cols-clipper {
+  margin-right: 16px
+}


### PR DESCRIPTION
Grids on inactive tabs get updated to height=0 when app reruns. Sometimes they update when switching to the tab they reside on, sometimes not. I saw inconsistent behavior depending on normal vs wide mode in settings. This PR seems to solve the issue on both. See #159 