### PR TITLE
MarshallComponentsException Fix

### DIFF
--- a/st_aggrid/__init__.py
+++ b/st_aggrid/__init__.py
@@ -345,11 +345,11 @@ def AgGrid(
             key=key
             )
 
-    except components.components.MarshallComponentException as ex:
+    except components.custom_component.MarshallComponentException as ex:
         #uses a more complete error message.
         args = list(ex.args)
         args[0] += ". If you're using custom JsCode objects on gridOptions, ensure that allow_unsafe_jscode is True."
-        ex = components.components.MarshallComponentException(*args)
+        ex = components.custom_component.MarshallComponentException(*args)
         raise(ex)
     
     if component_value:


### PR DESCRIPTION
Fixes "module 'streamlit.components.v1' has no attribute 'components'" by changing "components" to "custom_components".