### PR TITLE
remove dependency pin on altair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,11 @@ python = ">=3.8, !=3.9.7"
 streamlit = ">=0.87.0"
 pandas = ">=1.2"
 python-decouple = "^3.6"
-altair = "<5"
 
 [tool.poetry.dev-dependencies]
 black = "*"
 watchdog = "^2.1.9"
 
-[build-system]  
+[build-system]
 requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api" 
-
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
streamlit-aggrid has a dependency pin on altair, but it does not appear to be necessary.. removed it in this fork and tested with a local build in an app that uses this component.