### PR TITLE
Adds callback functionality #176 #151 #36 #298 #197 #207 #188

### DIFF
--- a/st_aggrid/AgGrid.py
+++ b/st_aggrid/AgGrid.py
@@ -411,6 +411,8 @@ def AgGrid(
             )
             inner_response._set_component_value(st.session_state[key])
             return callback(inner_response)
+    else:
+        _inner_callback = None
 
     response = AgGridReturn(
         data,

--- a/st_aggrid/AgGrid.py
+++ b/st_aggrid/AgGrid.py
@@ -385,35 +385,6 @@ def AgGrid(
         )
         gridOptions["autoSizeStrategy"] = {"type": "fitGridWidth"}
 
-
-    if callback and not key:
-        raise ValueError("Component key must be set to use a callback.")
-    elif key and not callback:
-        # This allows the table to keep its state up to date (eg #176)
-        def _inner_callback():
-            inner_response = AgGridReturn(
-                data,
-                gridOptions,
-                data_return_mode,
-                try_to_convert_back_to_original_types,
-                conversion_errors,
-            )
-            inner_response._set_component_value(st.session_state[key])
-    elif callback and key:
-        # User defined callback
-        def _inner_callback():
-            inner_response = AgGridReturn(
-                data,
-                gridOptions,
-                data_return_mode,
-                try_to_convert_back_to_original_types,
-                conversion_errors,
-            )
-            inner_response._set_component_value(st.session_state[key])
-            return callback(inner_response)
-    else:
-        _inner_callback = None
-
     response = AgGridReturn(
         data,
         gridOptions,
@@ -421,6 +392,23 @@ def AgGrid(
         try_to_convert_back_to_original_types,
         conversion_errors,
     )
+
+    if callback and not key:
+        raise ValueError("Component key must be set to use a callback.")
+    elif key and not callback:
+        # This allows the table to keep its state up to date (eg #176)
+        def _inner_callback():
+            response._set_component_value(st.session_state[key])
+    elif callback and key:
+        # User defined callback
+        def _inner_callback():
+            response._set_component_value(st.session_state[key])
+            return callback(response)
+    else:
+        _inner_callback = None
+
+
+
     try:
         component_value = _component_func(
             gridOptions=gridOptions,


### PR DESCRIPTION
This PR adds two new features:

- When `key` is set, keeps the table state up to date with user interactions. A consequence of this is much faster rendering of the table when it's hidden by something like `st.tabs` and re-revealed.
- When `key` and new arg `callback` is set, calls the provided `callback` callable with the table's `AgGridReturn` object.

This fixes or provides workarounds for several issues including #176 #151 #36 #298 #197 #207 and #188.