### PR TITLE
Fix Issue #313: new flag for enabling charts vs enterprise modules

### DIFF
--- a/st_aggrid/AgGrid.py
+++ b/st_aggrid/AgGrid.py
@@ -158,6 +158,7 @@ def AgGrid(
     data_return_mode: DataReturnMode = DataReturnMode.FILTERED_AND_SORTED,
     allow_unsafe_jscode: bool = False,
     enable_enterprise_modules: bool = False,
+    enable_charts: bool = False,
     license_key: str = None,
     try_to_convert_back_to_original_types: bool = True,
     conversion_errors: str = "coerce",
@@ -242,6 +243,10 @@ def AgGrid(
 
     enable_enterprise_modules : bool, optional
         Loads Ag-Grid enterprise modules (check licensing).
+        Defaults to False.
+
+    enable_charts: bool, optional
+        Loads Ag-Grid charts modules (check licensing).
         Defaults to False.
 
     license_key : str, optional
@@ -419,6 +424,7 @@ def AgGrid(
             frame_dtypes=frame_dtypes,
             allow_unsafe_jscode=allow_unsafe_jscode,
             enable_enterprise_modules=enable_enterprise_modules,
+            enable_charts=enable_charts,
             license_key=license_key,
             default=None,
             columns_state=columns_state,

--- a/st_aggrid/frontend/src/AgGrid.tsx
+++ b/st_aggrid/frontend/src/AgGrid.tsx
@@ -162,7 +162,11 @@ class AgGrid extends React.Component<ComponentProps, State> {
     }
 
     if (props.args.enable_enterprise_modules) {
-      ModuleRegistry.registerModules([AllEnterpriseModule.with(AgChartsEnterpriseModule)])
+      if (props.args.enable_charts) {
+        ModuleRegistry.registerModules([AllEnterpriseModule.with(AgChartsEnterpriseModule)])
+      } else {
+        ModuleRegistry.registerModules([AllEnterpriseModule])
+      }
       
       if ("license_key" in props.args) {
         LicenseManager.setLicenseKey(props.args["license_key"])


### PR DESCRIPTION
https://github.com/PablocFonseca/streamlit-aggrid/issues/313

Allow Enterprise users to utilize features that are not included in the AgGrid Enterprise + Charts umbrella.